### PR TITLE
FIX: fix memory issue, should use __bridge_transfer instead of __bridge.

### DIFF
--- a/oschina/Config.m
+++ b/oschina/Config.m
@@ -149,7 +149,7 @@
     else
     {
         CFUUIDRef uuid = CFUUIDCreate(kCFAllocatorDefault);
-        NSString * uuidString = (__bridge NSString *)CFUUIDCreateString(kCFAllocatorDefault, uuid);
+        NSString * uuidString = (__bridge_transfer NSString *)CFUUIDCreateString(kCFAllocatorDefault, uuid);
         CFRelease(uuid);
         [settings setObject:uuidString forKey:@"guid"];
         [settings synchronize];


### PR DESCRIPTION
CFUUIDCreateString(kCFAllocatorDefault, uuid); 创建了一个retain count 为1的对象，然后直接用 __bridge 转换成了NSString，而 __bridge 转换是指让ARC对转换后的对象不做内存管理。这样就会造成这个对象产生memory leak。

正确的做法是用 __bridge_transfer 将这个对象的owner transfer给转换后的 NSString对象，这样ARC就可以通过管理转换后的NSString对象来管理这个由 CoreFundation产生的对象了。

用xcode的 Analyze 工具可以验证以上想法。修改前Analyze报memory warning，改后恢复正常。
