### PR TITLE
Cache user icon 

### DIFF
--- a/oschina.xcodeproj/project.pbxproj
+++ b/oschina.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		45F10B6215F4F5A70058E253 /* TQImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 45F10B6115F4F5A70058E253 /* TQImageCache.m */; };
 		DA1763F4157C6AA400C7AE95 /* RTActiveCell.m in Sources */ = {isa = PBXBuildFile; fileRef = DA1763F2157C6AA400C7AE95 /* RTActiveCell.m */; };
 		DA1763F5157C6AA400C7AE95 /* RTActiveCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = DA1763F3157C6AA400C7AE95 /* RTActiveCell.xib */; };
 		DA1763F9157C6BCF00C7AE95 /* RTLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = DA1763F8157C6BCF00C7AE95 /* RTLabel.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -356,6 +357,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		45F10B6015F4F5A70058E253 /* TQImageCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TQImageCache.h; sourceTree = "<group>"; };
+		45F10B6115F4F5A70058E253 /* TQImageCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TQImageCache.m; sourceTree = "<group>"; };
 		DA1763F1157C6AA400C7AE95 /* RTActiveCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTActiveCell.h; sourceTree = "<group>"; };
 		DA1763F2157C6AA400C7AE95 /* RTActiveCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RTActiveCell.m; sourceTree = "<group>"; };
 		DA1763F3157C6AA400C7AE95 /* RTActiveCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = RTActiveCell.xib; sourceTree = "<group>"; };
@@ -860,6 +863,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		45F10B6415F4F5AF0058E253 /* cache */ = {
+			isa = PBXGroup;
+			children = (
+				45F10B6015F4F5A70058E253 /* TQImageCache.h */,
+				45F10B6115F4F5A70058E253 /* TQImageCache.m */,
+			);
+			name = cache;
+			sourceTree = "<group>";
+		};
 		DA16A7461562109A00A14D9D /* My */ = {
 			isa = PBXGroup;
 			children = (
@@ -1565,6 +1577,7 @@
 		DACC68A614FF8470006F7B6A /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				45F10B6415F4F5AF0058E253 /* cache */,
 				DABA75CC15046C8A00521596 /* AppModel */,
 				DA33587B150745B800F6671E /* Tweet.h */,
 				DA33587C150745B800F6671E /* Tweet.m */,
@@ -2104,6 +2117,7 @@
 				DACA288815EC633800874570 /* ChatPopView.m in Sources */,
 				DACA288C15EC6A0500874570 /* MyBubbleView.m in Sources */,
 				DA81A47D15F06273007CB958 /* SSPhotoCropperViewController.m in Sources */,
+				45F10B6215F4F5A70058E253 /* TQImageCache.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/oschina/PostsView.h
+++ b/oschina/PostsView.h
@@ -16,6 +16,7 @@
 #import "ShareView.h"
 
 #import "UITap.h"
+#import "TQImageCache.h"
 
 @interface PostsView : UIViewController<UITableViewDelegate,UITableViewDataSource,IconDownloaderDelegate,EGORefreshTableHeaderDelegate>
 {
@@ -29,6 +30,7 @@
     BOOL _reloading;
 
     BOOL isInitialize;
+    TQImageCache * _iconCache;
 }
 @property (strong, nonatomic) IBOutlet UITableView *tablePosts;
 //异步加载图片专用

--- a/oschina/TQImageCache.h
+++ b/oschina/TQImageCache.h
@@ -1,0 +1,32 @@
+//
+//  TQImageCAche.h
+//
+//
+//  Created by Tang Qiao on 12-5-9.
+//  Copyright (c) 2012年 blog.devtang.com. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef enum {
+    kLastCacheKitStatusNotFound,
+    kLastCacheKitStatusInMemory,
+    kLastCacheKitStatusInDisk
+} LastCacheKitStatus;
+
+@interface TQImageCache : NSObject
+
+@property (nonatomic, assign) NSInteger maxMemoryCacheNumber;
+@property (nonatomic, assign) LastCacheKitStatus lastCacheKitStatus;
+@property (nonatomic, retain) NSString * cachePath;
+
+
+- (id) initWithCachePath:(NSString*)path andMaxMemoryCacheNumber:(NSInteger)maxNumber;
+
+- (void) putImage:(NSData *) imageData withName:(NSString*)imageName ;
+- (NSData *) getImage:(NSString *)imageName;
+- (void)clear;
+
++ (NSString *)parseUrlForCacheName:(NSString *)name;
+
+@end

--- a/oschina/TQImageCache.m
+++ b/oschina/TQImageCache.m
@@ -16,13 +16,6 @@
 
 @end
 
-#ifdef DEBUG
-#define debugLog(...) NSLog(__VA_ARGS__)
-#define debugMethod() NSLog(@"%s", __func__)
-#else
-#define debugLog(...)
-#define debugMethod()
-#endif
 #define PATH_OF_TEMP        [NSHomeDirectory() stringByAppendingPathComponent:@"tmp"]
 
 @implementation TQImageCache;

--- a/oschina/TQImageCache.m
+++ b/oschina/TQImageCache.m
@@ -1,0 +1,148 @@
+//
+//  TQImageCache.m
+//
+//
+//  Created by Tang Qiao on 12-5-9.
+//  Copyright (c) 2012年 blog.devtang.com. All rights reserved.
+//
+
+#import "TQImageCache.h"
+
+@interface TQImageCache()
+
+@property (nonatomic, retain) NSFileManager * fileManager;
+@property (nonatomic, retain) NSMutableDictionary * memoryCache;
+@property (nonatomic, retain) NSMutableArray *memoryCacheKeys;
+
+@end
+
+#ifdef DEBUG
+#define debugLog(...) NSLog(__VA_ARGS__)
+#define debugMethod() NSLog(@"%s", __func__)
+#else
+#define debugLog(...)
+#define debugMethod()
+#endif
+#define PATH_OF_TEMP        [NSHomeDirectory() stringByAppendingPathComponent:@"tmp"]
+
+@implementation TQImageCache;
+
+static BOOL debugMode = NO;
+
+- (id) init {
+    return [self initWithCachePath:@"TQImageCache" andMaxMemoryCacheNumber:50];
+}
+
+- (id) initWithCachePath:(NSString*)path andMaxMemoryCacheNumber:(NSInteger)maxNumber {
+    NSString * tmpDir = PATH_OF_TEMP;
+    if ([path hasPrefix:tmpDir]) {
+        _cachePath = path;
+    } else {
+        if ([path length] != 0) {
+            _cachePath = [tmpDir stringByAppendingPathComponent:path];
+        } else {
+            return nil;
+        }
+    }
+    _maxMemoryCacheNumber = maxNumber;
+
+    if (self = [super init]) {
+        _fileManager = [NSFileManager defaultManager];
+        if ([_fileManager fileExistsAtPath:_cachePath isDirectory:nil] == NO) {
+            // create the directory
+            BOOL res = [_fileManager createDirectoryAtPath:_cachePath withIntermediateDirectories:YES attributes:nil error:nil];
+            if (!res) {
+                debugLog(@"file cache directory create failed! The path is %@", _cachePath);
+                return nil;
+            }
+        }
+        _memoryCache = [[NSMutableDictionary alloc] initWithCapacity:_maxMemoryCacheNumber + 1];
+        _memoryCacheKeys = [[NSMutableArray alloc] initWithCapacity:_maxMemoryCacheNumber + 1];
+        return self;
+    }
+    return nil;
+}
+
+- (void)clear {
+    _memoryCache = [[NSMutableDictionary alloc] initWithCapacity:_maxMemoryCacheNumber + 1];
+    _memoryCacheKeys = [[NSMutableArray alloc] initWithCapacity:_maxMemoryCacheNumber + 1];
+
+    // remove all the file in temporary
+    NSArray * files = [self.fileManager contentsOfDirectoryAtPath:self.cachePath error:nil];
+    for (NSString * file in files) {
+        if (debugMode) {
+            debugLog(@"remove cache file: %@", file);
+        }
+        [self.fileManager removeItemAtPath:file error:nil];
+    }
+}
+
+- (void) checkCacheSize {
+    if ([self.memoryCache count] > _maxMemoryCacheNumber) {
+        NSString * key = [self.memoryCacheKeys objectAtIndex:0];
+        [self.memoryCache removeObjectForKey:key];
+        [self.memoryCacheKeys removeObjectAtIndex:0];
+        if (debugMode) {
+            debugLog(@"remove oldest cache from memory: %@", key);
+        }
+    }
+}
+
+- (void) putImage:(NSData *) imageData withName:(NSString*)imageName {
+    if (imageData == nil) {
+        if (debugMode) {
+            debugLog(@"image data is nil");
+        }
+        return;
+    }
+    [self.memoryCache setObject:imageData forKey:imageName];
+    [self.memoryCacheKeys addObject:imageName];
+    [self checkCacheSize];
+    NSString * path = [self.cachePath stringByAppendingPathComponent:imageName];
+    [imageData writeToFile:path atomically:YES];
+    if (debugMode) {
+        debugLog(@"TQImageCache put cache image to %@", path);
+    }
+}
+
+- (NSData *) getImage:(NSString *)imageName {
+    NSData * data = [self.memoryCache objectForKey:imageName];
+    if (data != nil) {
+        if (debugMode) {
+            debugLog(@"TQImageCache hit cache from memory: %@", imageName);
+        }
+        self.lastCacheKitStatus = kLastCacheKitStatusInMemory;
+        return data;
+    }
+    NSString * path = [self.cachePath stringByAppendingPathComponent:imageName];
+    if ([self.fileManager fileExistsAtPath:path]) {
+        if (debugMode) {
+            debugLog(@"TQImageCache hit cache from file %@", path);
+        }
+        data = [NSData dataWithContentsOfFile:path];
+        // put it to memeory
+        [self.memoryCache setObject:data forKey:imageName];
+        [self.memoryCacheKeys addObject:imageName];
+        [self checkCacheSize];
+        self.lastCacheKitStatus = kLastCacheKitStatusInDisk;
+        return data;
+    }
+    self.lastCacheKitStatus = kLastCacheKitStatusNotFound;
+    return nil;
+}
+
+
++ (NSString *)parseUrlForCacheName:(NSString *)name {
+    if (name == nil) {
+        return nil;
+    }
+    name = [name stringByReplacingOccurrencesOfString:@"http://" withString:@""];
+    name = [name stringByReplacingOccurrencesOfString:@"://" withString:@"-"];
+    name = [name stringByReplacingOccurrencesOfString:@"/" withString:@"-"];
+    name = [NSString stringWithFormat:@"%@.png", name];
+    // debugLog(@"dest video url cache name :%@", name);
+    return name;
+}
+
+
+@end

--- a/oschina/oschina-Prefix.pch
+++ b/oschina/oschina-Prefix.pch
@@ -161,4 +161,12 @@
 
 #define AppVersion @"1.6.1"
 
+#ifdef DEBUG
+#define debugLog(...) NSLog(__VA_ARGS__)
+#define debugMethod() NSLog(@"%s", __func__)
+#else
+#define debugLog(...)
+#define debugMethod()
+#endif
+
 #endif


### PR DESCRIPTION
现在问答tab的用户头象都是没有缓存的，造成每次都需要请求用户头象，即使是简单的2个tab之间来回切换，也需要重新下载用户头象。这对网络请求浪费挺大的。所以加上了一个头象缓存类，在内存中缓存50个头象，更多头象缓存在tmp目录下。使得重复的头象不会多次产生网络请求。

另外，加了一个debugLog宏，可以用来Log一些信息，但是在发布Release版本的时候，会由于不带DEBUG宏而自动去掉这些Log信息。
